### PR TITLE
Fix Action error logging in updateWorkItem

### DIFF
--- a/index.js
+++ b/index.js
@@ -438,7 +438,8 @@ async function updateWorkItem(patchDocument, id, env) {
 	} catch (error) {
 		console.log("Error: updateWorkItem failed");
 		console.log(patchDocument);
-		core.setFailed(error);
+		console.log(error);
+		core.setFailed(error.toString());
 	}
 }
 


### PR DESCRIPTION
I started playing with this Action in a prototype repo/ADO instance to see what it was capable of and run through some hypothetical workflows.

My team uses a GitHub bot that tags incoming issues with "Needs: Triage :mag:" and I wanted to see if adding/removing that tag would sync correctly using this Action.  Except in my playground repo I used the Unicode Emoji 🔎 instead of the GitHub translated `:mag:`.

When I did this initially I ran into an issue where the Action failed with the error seen here: https://github.com/FalseLobster/scratchpad/runs/926155842?check_suite_focus=true

```
(node:2892) UnhandledPromiseRejectionWarning: TypeError: (s || "").replace is not a function
Error: updateWorkItem failed
    at escapeData (/home/runner/work/_actions/danhellem/github-actions-issue-to-work-item/1.5/node_modules/@actions/core/lib/command.js:66:10)
    at Command.toString (/home/runner/work/_actions/danhellem/github-actions-issue-to-work-item/1.5/node_modules/@actions/core/lib/command.js:60:35)
    at issueCommand (/home/runner/work/_actions/danhellem/github-actions-issue-to-work-item/1.5/node_modules/@actions/core/lib/command.js:23:30)
[
  {
    at Object.issue (/home/runner/work/_actions/danhellem/github-actions-issue-to-work-item/1.5/node_modules/@actions/core/lib/command.js:27:5)
    at error (/home/runner/work/_actions/danhellem/github-actions-issue-to-work-item/1.5/node_modules/@actions/core/lib/core.js:127:15)
    at Object.setFailed (/home/runner/work/_actions/danhellem/github-actions-issue-to-work-item/1.5/node_modules/@actions/core/lib/core.js:101:5)
    at main (/home/runner/work/_actions/danhellem/github-actions-issue-to-work-item/1.5/index.js:108:8)
    op: 'add',
    path: '/fields/System.Tags',
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
(node:2892) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:2892) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
This error is coming from inside @actions/core and appears to be because the type isn't a string and doesn't have a replace function on it.  

I was poking through forks of this repo and I saw someone had changed the error logging to stringify the exception object being passed to core.setFailed, which made sense.  Now the error message shows up in the top level Action result page:

https://github.com/FalseLobster/scratchpad/actions/runs/189151839

and the alert sub page includes the exception message as well:

```
Error: TF401407: The tag name is invalid. It contains invalid characters.
    at RestClient.<anonymous> (/home/runner/work/_actions/FalseLobster/github-actions-issue-to-work-item/tags/node_modules/typed-rest-client/RestClient.js:202:31)
    at Generator.next (<anonymous>)
    at fulfilled (/home/runner/work/_actions/FalseLobster/github-actions-issue-to-work-item/tags/node_modules/typed-rest-client/RestClient.js:6:58)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  statusCode: 400,
  result: {
    '$id': '1',
    innerException: null,
    message: 'TF401407: The tag name is invalid. It contains invalid characters.',
    typeName: 'Microsoft.Azure.Devops.Tags.Server.InvalidTagNameException, Microsoft.Azure.Devops.Tags.Server',
    typeKey: 'InvalidTagNameException',
    errorCode: 0,
    eventId: 3000
  }
```

Turns out that Azure DevOps doesn't support Unicode Emojis in tags (like 🔎), but it will translate the `:mag:` to its raw characters.  

Seems like this error logging change should get upstreamed, though :)