### PR TITLE
Add ability to use custom devops server hostname (aka on-premise)

### DIFF
--- a/index.js
+++ b/index.js
@@ -656,7 +656,7 @@ function getValuesFromPayload(payload, env) {
 		repository: "",
 		env: {
 			organization: env.ado_organization != undefined ? env.ado_organization : "",
-			orgUrl: env.ado_organization != undefined ? "https://dev.azure.com/" + env.ado_organization : "",
+			orgUrl: env.ado_url != undefined ? env.ado_url.replace(/\/+$/, '') + env.ado_organization : "https://dev.azure.com/" + env.ado_organization,
 			adoToken: env.ado_token != undefined ? env.ado_token : "",
 			ghToken: env.github_token != undefined ? env.github_token : "",
 			project: env.ado_project != undefined ? env.ado_project : "",

--- a/index.js
+++ b/index.js
@@ -656,7 +656,7 @@ function getValuesFromPayload(payload, env) {
 		repository: "",
 		env: {
 			organization: env.ado_organization != undefined ? env.ado_organization : "",
-			orgUrl: env.ado_url != undefined ? env.ado_url.replace(/\/+$/, '') + env.ado_organization : "https://dev.azure.com/" + env.ado_organization,
+			orgUrl: env.ado_url != undefined ? env.ado_url.replace(/\/+$/, '') + "/" + env.ado_organization : "https://dev.azure.com/" + env.ado_organization,
 			adoToken: env.ado_token != undefined ? env.ado_token : "",
 			ghToken: env.github_token != undefined ? env.github_token : "",
 			project: env.ado_project != undefined ? env.ado_project : "",


### PR DESCRIPTION
Add an option to override ``ado_url`` with custom domain name for local. It's work great with `self-hosted` github runners.

Config sample:
````
jobs:
  sync-devops:
    if: ${{ !github.event.issue.pull_request }}
    runs-on: self-hosted
    steps:
      - [...]
        env:
          NODE_TLS_REJECT_UNAUTHORIZED: 0
          ado_url: "https://devops700.itp.extra/"
          ado_organization: "700"
          ado_project: "SPFS-FRW"
          [...]
````