### PR TITLE
Expose Assigned User as an option on AzDo.  

### DIFF
--- a/index.js
+++ b/index.js
@@ -448,7 +448,7 @@ async function assigned(vm, workItem) {
   if (
     workItem.fields["System.AssignedTo"] != vm.env.assignedTo
   ) {
-    if (vm.env.assignedTo === "") {
+    if (vm.env.assignedTo == "") {
       console.log("Removing assigned to field");
 
       patchDocument.push({


### PR DESCRIPTION
Hi

I exposed the assigned to user fields so if people want, they can set it to assign the user.  I know this could get very repo use specific (cause you would have to map github to AzDo usernames) so no worries if you don't want to integrate it.  For my use case, I am going to pair it with a tool that will choose the right azdo email address based on the github assigned to username.  

Justification: 
Allow the user to set the assigned to field if they wish

Changes:

Exposed the Assigned To field upon creating/closing the github issue

Testing:

Saw the assigned user pop up when the azdo ticket loads
